### PR TITLE
add channel on update return value

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -62,7 +62,7 @@ class Channel extends EventEmitter {
       }
       changes.parent = this.parent
     }
-    this.emit('update', changes)
+    this.emit('update', this._client._channelById[msg.channel_id], changes)
   }
 
   setName (name) {


### PR DESCRIPTION
add channel on update return value
return value should include self object (Channel).

Listener can't get channel id when channel on update.
cause `changes` only have channel name without channel id